### PR TITLE
Compatibility with iOS 6 (tested only on simulator)

### DIFF
--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -231,8 +231,10 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	
 	if (self.targetViewController) {
 		[self willMoveToParentViewController:self.targetViewController];
-		self.targetViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
-		[self.targetViewController.view tintColorDidChange];
+        if ([UIView respondsToSelector:@selector(setTintColor:)]) {
+            self.targetViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
+            [self.targetViewController.view tintColorDidChange];
+        };
 		[self.targetViewController addChildViewController:self];
 		[self.targetViewController.view addSubview:self.view];
 		
@@ -243,8 +245,10 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	}
 	else {
 		// add this view to the main window if no targetViewController was set
-		self.keyWindow.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
-		[self.keyWindow tintColorDidChange];
+        if ([UIView respondsToSelector:@selector(setTintColor:)]) {
+            self.keyWindow.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
+            [self.keyWindow tintColorDidChange];
+        };
 		[self.keyWindow addSubview:self.view];
 		
 		if (self.snapshotView) {
@@ -448,14 +452,18 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	[self.view removeFromSuperview];
 	
 	if (self.targetViewController) {
-		self.targetViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
-		[self.targetViewController.view tintColorDidChange];
+        if ([UIView respondsToSelector:@selector(setTintColor:)]) {
+            self.targetViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
+            [self.targetViewController.view tintColorDidChange];
+        };
 		[self willMoveToParentViewController:nil];
 		[self removeFromParentViewController];
 	}
 	else {
-		self.keyWindow.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
-		[self.keyWindow tintColorDidChange];
+        if ([UIView respondsToSelector:@selector(setTintColor:)]) {
+            self.keyWindow.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
+            [self.keyWindow tintColorDidChange];
+        };
 	}
 	[self.animator removeAllBehaviors];
 	[[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];


### PR DESCRIPTION
Seems to work on simulator, don't have any iOS6 device available now.
I did this just by checking `[UIView respondsToSelector:@selector(setTintColor:)` before any tintColor related stuff. 
The photo cannot be moved but at least you can see it on fullscreen, zoom in and tap to dismiss, maybe this part can be improved.
