### PR TITLE
Pinching to shrink the image scale to < 1.0 adds the UIPanGesture back, even if you're still zooming

### DIFF
--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -580,7 +580,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 
 - (void)scrollViewDidZoom:(UIScrollView *)scrollView {
 	// zoomScale of 1.0 is always our starting point, so anything other than that we disable the pan gesture recognizer
-	if (scrollView.zoomScale <= 1.0f) {
+	if (scrollView.zoomScale <= 1.0f && !scrollView.zooming) {
 		[self.imageView addGestureRecognizer:self.panRecognizer];
 		scrollView.scrollEnabled = NO;
 	}


### PR DESCRIPTION
This caused the image to flicker between two positions on screen.

Reproducible by pinching/zooming out (to smaller than 1.0 scale) in the center of the screen and then dragging away from the center of the screen while holding two fingers/still pinching.
