### PR TITLE
Improve interface rotation behavior when used with view controller containment 

### DIFF
--- a/SampleProject/URBMediaFocusViewControllerDemo/DemoViewController.m
+++ b/SampleProject/URBMediaFocusViewControllerDemo/DemoViewController.m
@@ -96,13 +96,13 @@
 	//[self.mediaFocusController showImage:[UIImage imageNamed:@"seattle01.jpg"] fromView:self.thumbnailView inView:self.view];
 	
 	if (gestureRecognizer.view == self.localThumbnailView) {
-		[self.mediaFocusController showImage:[UIImage imageNamed:@"raceforfood.jpg"] fromView:gestureRecognizer.view];
+		[self.mediaFocusController showImage:[UIImage imageNamed:@"raceforfood.jpg"] fromView:gestureRecognizer.view inViewController:self];
 	}
 	else if (gestureRecognizer.view == self.panoramaThumbnailView) {
-		[self.mediaFocusController showImage:[UIImage imageNamed:@"panorama.jpg"] fromView:gestureRecognizer.view];
+		[self.mediaFocusController showImage:[UIImage imageNamed:@"panorama.jpg"] fromView:gestureRecognizer.view inViewController:self];
 	}
 	else if (gestureRecognizer.view == self.verticalPanoramaThumbnailView) {
-		[self.mediaFocusController showImage:[UIImage imageNamed:@"panorama_vert.jpg"] fromView:gestureRecognizer.view];
+		[self.mediaFocusController showImage:[UIImage imageNamed:@"panorama_vert.jpg"] fromView:gestureRecognizer.view inViewController:self];
 	}
 	else {
 		NSURL *url;
@@ -115,7 +115,7 @@
 		else {
 			url = [NSURL URLWithString:@"http://farm3.staticflickr.com/2109/5763011359_f371b21fc9_b.jpg"];
 		}
-		[self.mediaFocusController showImageFromURL:url fromView:gestureRecognizer.view];
+		[self.mediaFocusController showImageFromURL:url fromView:gestureRecognizer.view inViewController:self];
 		
 		// alternative method adding the focus view to this controller's view
 		//[self.mediaFocusController showImageFromURL:url fromView:gestureRecognizer.view inViewController:self];

--- a/SampleProject/URBMediaFocusViewControllerDemo/DemoViewController.m
+++ b/SampleProject/URBMediaFocusViewControllerDemo/DemoViewController.m
@@ -26,7 +26,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-	
+	[self.view setBackgroundColor:[UIColor whiteColor]];
+    
 	self.mediaFocusController = [[URBMediaFocusViewController alloc] init];
 	self.mediaFocusController.delegate = self;
 	//self.mediaFocusController.shouldDismissOnTap = NO; // uncomment if you wish to disable dismissing the view on a single tap outside image bounds

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -438,42 +438,6 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.blurredSnapshotView = snapshotView;
 }
 
-- (void)adjustFrame {
-	CGRect imageFrame = self.imageView.frame;
-	
-	// snap x sides
-	if (CGRectGetWidth(imageFrame) > CGRectGetWidth(self.view.frame)) {
-		if (CGRectGetMinX(imageFrame) > 0) {
-			imageFrame.origin.x = 0;
-		}
-		else if (CGRectGetMaxX(imageFrame) < CGRectGetWidth(self.view.frame)) {
-			imageFrame.origin.x = CGRectGetWidth(self.view.frame) - CGRectGetWidth(imageFrame);
-		}
-	}
-	else if (self.imageView.center.x != CGRectGetMidX(self.view.frame)) {
-		imageFrame.origin.x = CGRectGetMidX(self.view.frame) - CGRectGetWidth(imageFrame) / 2.0f;
-	}
-	
-	// snap y sides
-	if (CGRectGetHeight(imageFrame) > CGRectGetHeight(self.view.frame)) {
-		if (CGRectGetMinY(imageFrame) > 0) {
-			imageFrame.origin.y = 0;
-		}
-		else if (CGRectGetMaxY(imageFrame) < CGRectGetHeight(self.view.frame)) {
-			imageFrame.origin.y = CGRectGetHeight(self.view.frame) - CGRectGetHeight(imageFrame);
-		}
-	}
-	else if (self.imageView.center.y != CGRectGetMidY(self.view.frame)) {
-		imageFrame.origin.y = CGRectGetMidY(self.view.frame) - CGRectGetHeight(imageFrame) / 2.0f;
-	}
-	
-	[UIView animateWithDuration:0.3f delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-		self.imageView.frame = imageFrame;
-	} completion:^(BOOL finished) {
-		
-	}];
-}
-
 /**
  *	When adding UIDynamics to a view, it resets `zoomScale` on UIScrollView back to 1.0, which is an issue when applying dynamics
  *	to the imageView when scaled down. So we just scale the imageView.frame while dynamics are applied.

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -103,79 +103,78 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 }
 
 - (void)setup {
-	self.backgroundView = [[UIView alloc] initWithFrame:self.view.bounds];
-	self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.6f];
-	self.backgroundView.alpha = 0.0f;
-	self.backgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
-	[self.view addSubview:self.backgroundView];
-	
-	self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
-	self.scrollView.backgroundColor = [UIColor clearColor];
-	self.scrollView.delegate = self;
-	self.scrollView.showsHorizontalScrollIndicator = NO;
-	self.scrollView.showsVerticalScrollIndicator = NO;
-	self.scrollView.scrollEnabled = NO;
-    self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
-	[self.view addSubview:self.scrollView];
-	
-	self.imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 50.0, 50.0)];
-	self.imageView.contentMode = UIViewContentModeScaleAspectFit;
-    self.imageView.autoresizingMask = UIViewAutoresizingNone;
-	self.imageView.alpha = 0.0f;
-	self.imageView.userInteractionEnabled = YES;
-	[self.scrollView addSubview:self.imageView];
+    self.backgroundView = [[UIView alloc] initWithFrame:self.view.bounds];
+    self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.6f];
+    self.backgroundView.alpha = 0.0f;
+    self.backgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self.view addSubview:self.backgroundView];
     
-	/* setup gesture recognizers */
-	// double tap gesture to return scaled image back to center for easier dismissal
-	self.doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTapGesture:)];
-	self.doubleTapRecognizer.delegate = self;
-	self.doubleTapRecognizer.numberOfTapsRequired = 2;
-	self.doubleTapRecognizer.numberOfTouchesRequired = 1;
-	[self.imageView addGestureRecognizer:self.doubleTapRecognizer];
-	
-	// tap recognizer on area outside image view for dismissing
-	self.tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissFromTap:)];
-	self.tapRecognizer.delegate = self;
-	self.tapRecognizer.numberOfTapsRequired = 1;
-	self.tapRecognizer.numberOfTouchesRequired = 1;
-	[self.tapRecognizer requireGestureRecognizerToFail:self.doubleTapRecognizer];
-	[self.view addGestureRecognizer:self.tapRecognizer];
-	
-	// only add pan gesture and physics stuff if we can (e.g., iOS 7+)
-	if (NSClassFromString(@"UIDynamicAnimator")) {
-		// pan gesture to handle the physics
-		self.panRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
-		self.panRecognizer.delegate = self;
-		[self.imageView addGestureRecognizer:self.panRecognizer];
-		
-		/* UIDynamics stuff */
-		self.animator = [[UIDynamicAnimator alloc] initWithReferenceView:self.view];
-		self.animator.delegate = self;
-		
-		// snap behavior to keep image view in the center as needed
-		self.snapBehavior = [[UISnapBehavior alloc] initWithItem:self.imageView snapToPoint:self.view.center];
-		self.snapBehavior.damping = 1.0f;
-		
-		self.pushBehavior = [[UIPushBehavior alloc] initWithItems:@[self.imageView] mode:UIPushBehaviorModeInstantaneous];
-		self.pushBehavior.angle = 0.0f;
-		self.pushBehavior.magnitude = 0.0f;
-		
-		self.itemBehavior = [[UIDynamicItemBehavior alloc] initWithItems:@[self.imageView]];
-		self.itemBehavior.elasticity = 0.0f;
-		self.itemBehavior.friction = 0.2f;
-		self.itemBehavior.allowsRotation = YES;
-		self.itemBehavior.density = __density;
-		self.itemBehavior.resistance = __resistance;
-	}
-	else {
-		// add tap gesture to image to also dismiss since we don't have UIDynamics to flick out of view
-		self.photoTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissFromTap:)];
-		self.photoTapRecognizer.delegate = self;
-		self.photoTapRecognizer.numberOfTapsRequired = 1;
-		self.photoTapRecognizer.numberOfTouchesRequired = 1;
-		[self.photoTapRecognizer requireGestureRecognizerToFail:self.doubleTapRecognizer];
-		[self.imageView addGestureRecognizer:self.photoTapRecognizer];
-	}
+    self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
+    self.scrollView.backgroundColor = [UIColor clearColor];
+    self.scrollView.delegate = self;
+    self.scrollView.showsHorizontalScrollIndicator = NO;
+    self.scrollView.showsVerticalScrollIndicator = NO;
+    self.scrollView.scrollEnabled = NO;
+    self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self.view addSubview:self.scrollView];
+    
+    self.imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 50.0, 50.0)];
+    self.imageView.contentMode = UIViewContentModeScaleAspectFit;
+    self.imageView.autoresizingMask = UIViewAutoresizingNone;
+    self.imageView.alpha = 0.0f;
+    self.imageView.userInteractionEnabled = YES;
+    [self.scrollView addSubview:self.imageView];
+    
+    /* setup gesture recognizers */
+    // double tap gesture to return scaled image back to center for easier dismissal
+    self.doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTapGesture:)];
+    self.doubleTapRecognizer.delegate = self;
+    self.doubleTapRecognizer.numberOfTapsRequired = 2;
+    self.doubleTapRecognizer.numberOfTouchesRequired = 1;
+    [self.imageView addGestureRecognizer:self.doubleTapRecognizer];
+    
+    // tap recognizer on area outside image view for dismissing
+    self.tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissFromTap:)];
+    self.tapRecognizer.delegate = self;
+    self.tapRecognizer.numberOfTapsRequired = 1;
+    self.tapRecognizer.numberOfTouchesRequired = 1;
+    [self.tapRecognizer requireGestureRecognizerToFail:self.doubleTapRecognizer];
+    [self.view addGestureRecognizer:self.tapRecognizer];
+    
+    // only add pan gesture and physics stuff if we can (e.g., iOS 7+)
+    if (NSClassFromString(@"UIDynamicAnimator")) {
+        // pan gesture to handle the physics
+        self.panRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+        self.panRecognizer.delegate = self;
+        [self.imageView addGestureRecognizer:self.panRecognizer];
+        
+        /* UIDynamics stuff */
+        self.animator = [[UIDynamicAnimator alloc] initWithReferenceView:self.view];
+        self.animator.delegate = self;
+        
+        // snap behavior to keep image view in the center as needed
+        self.snapBehavior = [[UISnapBehavior alloc] initWithItem:self.imageView snapToPoint:self.view.center];
+        self.snapBehavior.damping = 1.0f;
+        
+        self.pushBehavior = [[UIPushBehavior alloc] initWithItems:@[self.imageView] mode:UIPushBehaviorModeInstantaneous];
+        self.pushBehavior.angle = 0.0f;
+        self.pushBehavior.magnitude = 0.0f;
+        
+        self.itemBehavior = [[UIDynamicItemBehavior alloc] initWithItems:@[self.imageView]];
+        self.itemBehavior.elasticity = 0.0f;
+        self.itemBehavior.friction = 0.2f;
+        self.itemBehavior.allowsRotation = YES;
+        self.itemBehavior.density = __density;
+        self.itemBehavior.resistance = __resistance;
+    } else {
+        // add tap gesture to image to also dismiss since we don't have UIDynamics to flick out of view
+        self.photoTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissFromTap:)];
+        self.photoTapRecognizer.delegate = self;
+        self.photoTapRecognizer.numberOfTapsRequired = 1;
+        self.photoTapRecognizer.numberOfTouchesRequired = 1;
+        [self.photoTapRecognizer requireGestureRecognizerToFail:self.doubleTapRecognizer];
+        [self.imageView addGestureRecognizer:self.photoTapRecognizer];
+    }
     
 #if defined(DEBUG) && defined(URBMediaFocusViewControllerShowBorders)
     [self.scrollView.layer setBorderColor:[[UIColor colorWithRed:1.0 green:0. blue:0.0 alpha:0.5] CGColor]];
@@ -190,7 +189,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
     
-	self.view.frame = [self keyView].bounds;
+    self.view.frame = [self keyView].bounds;
     
     [self updateScrollViewScalesAndImagePosition];
     [self layoutBackground];
@@ -199,10 +198,11 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 - (void)updateScrollViewScalesAndImagePosition {
     // update scrollView.contentSize to the size of the image
     UIImage *image = self.imageView.image;
-	self.scrollView.contentSize = image.size;
-	CGFloat scaleWidth = CGRectGetWidth(self.scrollView.frame) / self.scrollView.contentSize.width;
-	CGFloat scaleHeight = CGRectGetHeight(self.scrollView.frame) / self.scrollView.contentSize.height;
-	CGFloat scale = MIN(scaleWidth, scaleHeight);
+    
+    self.scrollView.contentSize = image.size;
+    CGFloat scaleWidth = CGRectGetWidth(self.scrollView.frame) / self.scrollView.contentSize.width;
+    CGFloat scaleHeight = CGRectGetHeight(self.scrollView.frame) / self.scrollView.contentSize.height;
+    CGFloat scale = MIN(scaleWidth, scaleHeight);
     
     self.scrollView.contentOffset = CGPointZero;
     
@@ -215,9 +215,9 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     }
     
     self.scrollView.zoomScale = 1.0;
-	// image view's destination frame is the size of the image capped to the width/height of the target view
-	CGSize scaledImageSize = CGSizeMake(image.size.width * scale, image.size.height * scale);
-	self.imageView.bounds = CGRectMake(0,0, scaledImageSize.width, scaledImageSize.height);;
+    // image view's destination frame is the size of the image capped to the width/height of the target view
+    CGSize scaledImageSize = CGSizeMake(image.size.width * scale, image.size.height * scale);
+    self.imageView.bounds = CGRectMake(0, 0, scaledImageSize.width, scaledImageSize.height);
     [self centerScrollViewContents];
     _originalFrame = self.imageView.frame;
 }
@@ -495,41 +495,41 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 }
 
 - (UIView *)keyView {
-    return self.targetViewController.view ?: self.keyWindow;
+    return self.targetViewController.view ? : self.keyWindow;
 }
 
 - (void)createViewsForParallax {
     UIView *sourceView = [self keyView];
     
-	// container view for window
-	// inset container view so we can blur the edges, but we also need to scale up so when __backgroundScale is applied, everything lines up
-	CGRect containerFrame = sourceView.bounds;
+    // container view for window
+    // inset container view so we can blur the edges, but we also need to scale up so when __backgroundScale is applied, everything lines up
+    CGRect containerFrame = sourceView.bounds;
     CGFloat blurInset = 3 * __blurRadius;
-	UIView *containerView = [[UIView alloc] initWithFrame:CGRectInset(containerFrame, -blurInset, -blurInset)];
-	containerView.backgroundColor = [UIColor blackColor];
-	
-	// add snapshot of window to the container
+    UIView *containerView = [[UIView alloc] initWithFrame:CGRectInset(containerFrame, -blurInset, -blurInset)];
+    
+    containerView.backgroundColor = [UIColor blackColor];
+    
+    // add snapshot of window to the container
     UIImageView *windowSnapshotView = [[UIImageView alloc] initWithImage:nil];
     windowSnapshotView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-	windowSnapshotView.frame = CGRectInset(containerView.bounds, blurInset, blurInset);
+    windowSnapshotView.frame = CGRectInset(containerView.bounds, blurInset, blurInset);
     windowSnapshotView.backgroundColor = [UIColor blackColor];
     
-	self.snapshotView = windowSnapshotView;
-	[containerView addSubview:windowSnapshotView];
-	
+    self.snapshotView = windowSnapshotView;
+    [containerView addSubview:windowSnapshotView];
     
-	// only add blurred view if radius is above 0
-	if (self.shouldBlurBackground && __blurRadius) {
-		UIImageView *snapshotView = [[UIImageView alloc] initWithImage:nil];
+    // only add blurred view if radius is above 0
+    if (self.shouldBlurBackground && __blurRadius) {
+        UIImageView *snapshotView = [[UIImageView alloc] initWithImage:nil];
         snapshotView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-		snapshotView.alpha = 0.0f;
-		snapshotView.userInteractionEnabled = NO;
+        snapshotView.alpha = 0.0f;
+        snapshotView.userInteractionEnabled = NO;
         snapshotView.frame = containerView.bounds;
         self.blurredSnapshotView = snapshotView;
         [containerView addSubview:snapshotView];
-	}
+    }
     
-	self.snapshotsContainerView = containerView;
+    self.snapshotsContainerView = containerView;
     [self updateSnapshotContents];
     
 #if defined(DEBUG) && defined(URBMediaFocusViewControllerShowBorders)
@@ -546,6 +546,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     if (!self.snapshotsContainerView) {
         return;
     }
+    
     [self layoutBackground];
     
     // because we might have polluted the view of our target
@@ -554,7 +555,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     [self.originalTargetContentHidingView setHidden:YES];
     [self.snapshotsContainerView setHidden:YES];
     [self.backgroundView setHidden:YES];
-
+    
     UIView *sourceView = [self keyView];
     UIImage *windowSnapshot = [sourceView snapshotImageWithScale:[UIScreen mainScreen].scale];
     
@@ -564,7 +565,6 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     [self.backgroundView setHidden:NO];
     
     [self.snapshotView setImage:windowSnapshot];
-    
     
     if (self.blurredSnapshotView) {
         // create the blurred snapshot
@@ -591,10 +591,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
         [self.snapshotView setAlpha:alphaBefore];
         [self.snapshotsContainerView setAlpha:snapShotContainerAlpha];
     }
-    
-    
 }
-
 
 /**
  *	When adding UIDynamics to a view, it resets `zoomScale` on UIScrollView back to 1.0, which is an issue when applying dynamics

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -302,7 +302,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.fromView = fromView;
 	self.targetViewController = parentViewController;
 	
-	CGRect fromRect = [self.view convertRect:fromView.frame fromView:nil];
+	CGRect fromRect = (self.fromView) ? [self.fromView convertRect:self.fromView.bounds toView:self.targetViewController.view] : CGRectZero;
 	[self showImage:image fromRect:fromRect];
 }
 
@@ -318,7 +318,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.imageView.transform = CGAffineTransformIdentity;
 	self.imageView.image = image;
 	self.imageView.alpha = 0.2;
-	
+    
 	// create snapshot of background if parallax is enabled
 	if (self.parallaxEnabled) {
 		[self createViewsForParallax];
@@ -333,7 +333,13 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 
 	// set initial frame of image view to match that of the presenting image
 	//self.imageView.frame = CGRectMake(midpoint.x - image.size.width / 2.0, midpoint.y - image.size.height / 2.0, image.size.width, image.size.height);
-	self.imageView.frame = [self.view convertRect:fromRect fromView:nil];
+	if (self.targetViewController) {
+        // when using the target view controller, both view controllers will have same geometry:
+        self.imageView.bounds = CGRectMake(0, 0, CGRectGetWidth(fromRect), CGRectGetHeight(fromRect));
+        self.imageView.center = CGPointMake(CGRectGetMidX(fromRect), CGRectGetMidY(fromRect));
+    } else {
+        self.imageView.frame = [self.view convertRect:fromRect fromView:nil];
+    }
     
 	// rotate imageView based on current device orientation
 	[self reposition];
@@ -385,7 +391,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     
     [self layoutBackground];
 	
-	[UIView animateWithDuration:__animationDuration delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
+	[UIView animateWithDuration:__animationDuration delay:0 options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState animations:^{
 		self.backgroundView.alpha = 1.0f;
 		self.imageView.alpha = 1.0f;
         [self updateScrollViewScalesAndImagePosition];

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -104,7 +104,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 
 - (void)setup {
 	self.backgroundView = [[UIView alloc] initWithFrame:self.view.bounds];
-	self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.16f];
+	self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.6f];
 	self.backgroundView.alpha = 0.0f;
 	self.backgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
 	[self.view addSubview:self.backgroundView];
@@ -124,13 +124,6 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.imageView.alpha = 0.0f;
 	self.imageView.userInteractionEnabled = YES;
 	[self.scrollView addSubview:self.imageView];
-    
-#if defined(DEBUG) && defined(URBMediaFocusViewControllerShowBorders)
-    [self.scrollView.layer setBorderColor:[[UIColor colorWithRed:1.0 green:0. blue:0.0 alpha:0.5] CGColor]];
-    [self.scrollView.layer setBorderWidth:1];
-    [self.imageView.layer setBorderColor:[[UIColor greenColor] CGColor]];
-    [self.imageView.layer setBorderWidth:1];
-#endif
     
 	/* setup gesture recognizers */
 	// double tap gesture to return scaled image back to center for easier dismissal
@@ -183,6 +176,13 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 		[self.photoTapRecognizer requireGestureRecognizerToFail:self.doubleTapRecognizer];
 		[self.imageView addGestureRecognizer:self.photoTapRecognizer];
 	}
+    
+#if defined(DEBUG) && defined(URBMediaFocusViewControllerShowBorders)
+    [self.scrollView.layer setBorderColor:[[UIColor colorWithRed:1.0 green:0. blue:0.0 alpha:0.5] CGColor]];
+    [self.scrollView.layer setBorderWidth:1];
+    [self.imageView.layer setBorderColor:[[UIColor greenColor] CGColor]];
+    [self.imageView.layer setBorderWidth:1];
+#endif
 }
 
 - (void)viewDidLayoutSubviews {

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -111,14 +111,23 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.scrollView.showsHorizontalScrollIndicator = NO;
 	self.scrollView.showsVerticalScrollIndicator = NO;
 	self.scrollView.scrollEnabled = NO;
+    self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
 	[self.view addSubview:self.scrollView];
 	
 	self.imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 50.0, 50.0)];
 	self.imageView.contentMode = UIViewContentModeScaleAspectFit;
+    self.imageView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin;
 	self.imageView.alpha = 0.0f;
 	self.imageView.userInteractionEnabled = YES;
 	[self.scrollView addSubview:self.imageView];
-	
+    
+#if DEBUG
+    [self.scrollView.layer setBorderColor:[[UIColor redColor] CGColor]];
+    [self.scrollView.layer setBorderWidth:1];
+    [self.imageView.layer setBorderColor:[[UIColor greenColor] CGColor]];
+    [self.imageView.layer setBorderWidth:1];
+#endif
+    
 	/* setup gesture recognizers */
 	// double tap gesture to return scaled image back to center for easier dismissal
 	self.doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTapGesture:)];
@@ -172,6 +181,11 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	}
 }
 
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    [self centerScrollViewContents];
+}
+
 - (void)cancelURLConnectionIfAny {
     if (self.loadingView) {
         [self.loadingView stopAnimating];
@@ -196,6 +210,10 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 
 - (void)showImage:(UIImage *)image fromRect:(CGRect)fromRect {
 	[self view]; // make sure view has loaded first
+    if (self.targetViewController) {
+        // ensure that view has same bounds as target view controller
+        [self.view setFrame:self.targetViewController.view.bounds];
+    }
 	_currentOrientation = [UIApplication sharedApplication].statusBarOrientation;
 	self.fromRect = fromRect;
 	
@@ -712,6 +730,9 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 #pragma mark - Orientation Helpers
 
 - (void)deviceOrientationChanged:(NSNotification *)notification {
+    if (self.targetViewController) {
+        return;
+    }
 	NSLog(@"device orientation changed");
 	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
 	if (_currentOrientation != orientation) {
@@ -738,6 +759,9 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 }
 
 - (void)reposition {
+    if (self.targetViewController) {
+        return;
+    }
 	CGAffineTransform baseTransform = [self transformForOrientation:_currentOrientation];
 	
 	// determine if the rotation we're about to undergo is 90 or 180 degrees

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -188,7 +188,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
     
-	self.view.frame = self.targetViewController ? self.targetViewController.view.bounds : self.keyWindow.bounds;
+	self.view.frame = [self keyView].bounds;
     
     [self updateScrollViewScalesAndImagePosition];
     [self layoutBackground];
@@ -302,7 +302,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     }
     
     
-    UIView *targetView = self.targetViewController.view?:self.keyWindow;
+    UIView *targetView = [self keyView];
     
 	if (self.targetViewController) {
 		[self willMoveToParentViewController:self.targetViewController];
@@ -465,8 +465,12 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	return [UIApplication sharedApplication].keyWindow;
 }
 
+- (UIView *)keyView {
+    return self.targetViewController.view ?: self.keyWindow;
+}
+
 - (void)createViewsForParallax {
-    UIView *sourceView = self.targetViewController.view ?: self.keyWindow;
+    UIView *sourceView = [self keyView];
     
 	// container view for window
 	// inset container view so we can blur the edges, but we also need to scale up so when __backgroundScale is applied, everything lines up
@@ -522,7 +526,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     [self.snapshotsContainerView setHidden:YES];
     [self.backgroundView setHidden:YES];
 
-    UIView *sourceView = self.targetViewController.view ?: self.keyWindow;
+    UIView *sourceView = [self keyView];
     UIImage *windowSnapshot = [sourceView snapshotImageWithScale:[UIScreen mainScreen].scale];
     
     [self.view setHidden:NO];

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -9,7 +9,7 @@
 #import <Accelerate/Accelerate.h>
 #import "URBMediaFocusViewController.h"
 
-static const CGFloat __overlayAlpha = 0.7f;						// opacity of the black overlay displayed below the focused image
+static const CGFloat __overlayAlpha = 0.6f;						// opacity of the black overlay displayed below the focused image
 static const CGFloat __animationDuration = 0.18f;				// the base duration for present/dismiss animations (except physics-related ones)
 static const CGFloat __maximumDismissDelay = 0.5f;				// maximum time of delay (in seconds) between when image view is push out and dismissal animations begin
 static const CGFloat __resistance = 0.0f;						// linear resistance applied to the image’s dynamic item behavior
@@ -104,7 +104,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 
 - (void)setup {
     self.backgroundView = [[UIView alloc] initWithFrame:self.view.bounds];
-    self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.6f];
+    self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:__overlayAlpha];
     self.backgroundView.alpha = 0.0f;
     self.backgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.backgroundView];

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -503,10 +503,26 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 }
 
 - (void)centerScrollViewContents {
-	CGSize contentSize = self.scrollView.contentSize;
-	CGFloat offsetX = (CGRectGetWidth(self.scrollView.frame) - contentSize.width) / 2.0f;
-	CGFloat offsetY = (CGRectGetHeight(self.scrollView.frame) - contentSize.height) / 2.0f;
-	self.imageView.center = CGPointMake(self.scrollView.contentSize.width / 2.0f + offsetX, self.scrollView.contentSize.height / 2.0f + offsetY);
+    // from apple photoScroller example
+    // center the zoom view as it becomes smaller than the size of the screen
+    CGSize boundsSize = self.scrollView.bounds.size;
+    CGRect frameToCenter = self.imageView.frame;
+    
+    // center horizontally
+    if (frameToCenter.size.width < boundsSize.width) {
+        frameToCenter.origin.x = (boundsSize.width - frameToCenter.size.width) / 2;
+    } else {
+        frameToCenter.origin.x = 0;
+    }
+    
+    // center vertically
+    if (frameToCenter.size.height < boundsSize.height) {
+        frameToCenter.origin.y = (boundsSize.height - frameToCenter.size.height) / 2;
+    } else {
+        frameToCenter.origin.y = 0;
+    }
+    
+    self.imageView.frame = frameToCenter;
 }
 
 - (void)returnToCenter {

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -28,6 +28,10 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 - (UIImage *)snapshotImageWithScale:(CGFloat)scale;
 @end
 
+
+/// Uncomment the following line to display borders around some views for easier debugging
+/// #define URBMediaFocusViewControllerShowBorders
+
 /**
  Pulled from Apple's UIImage+ImageEffects category, but renamed to avoid potential selector name conflicts.
  */
@@ -121,7 +125,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.imageView.userInteractionEnabled = YES;
 	[self.scrollView addSubview:self.imageView];
     
-#if DEBUG
+#if defined(DEBUG) && defined(URBMediaFocusViewControllerShowBorders)
     [self.scrollView.layer setBorderColor:[[UIColor colorWithRed:1.0 green:0. blue:0.0 alpha:0.5] CGColor]];
     [self.scrollView.layer setBorderWidth:1];
     [self.imageView.layer setBorderColor:[[UIColor greenColor] CGColor]];
@@ -475,7 +479,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.snapshotView = windowSnapshotView;
 	self.blurredSnapshotView = snapshotView;
     
-#if DEBUG
+#if defined(DEBUG) && defined(URBMediaFocusViewControllerShowBorders)
     [self.snapshotsContainerView.layer setBorderColor:[[UIColor yellowColor] CGColor]];
     [self.snapshotsContainerView.layer setBorderWidth:1];
     [self.snapshotView.layer setBorderColor:[[UIColor greenColor] CGColor]];

--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -310,7 +310,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	[self view]; // make sure view has loaded first
     if (self.targetViewController) {
         // ensure that view has same bounds as target view controller
-        [self.view setFrame:self.targetViewController.view.bounds];
+        self.view.frame = [self keyView].bounds;
     }
 	_currentOrientation = [UIApplication sharedApplication].statusBarOrientation;
 	self.fromRect = fromRect;


### PR DESCRIPTION
This improves the interface rotation behavior when used with view controller containment. Some issue with the original rect for the presentation (when reusing the same view controller) and dismissal remain.
