### PR TITLE
Turn on edge anti-aliasing in iOS 7.0 and later

### DIFF
--- a/URBMediaFocusViewController.m
+++ b/URBMediaFocusViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import <Accelerate/Accelerate.h>
+#import <QuartzCore/QuartzCore.h>
 #import "URBMediaFocusViewController.h"
 
 static const CGFloat __overlayAlpha = 0.7f;						// opacity of the black overlay displayed below the focused image
@@ -117,6 +118,11 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
 	self.imageView.contentMode = UIViewContentModeScaleAspectFit;
 	self.imageView.alpha = 0.0f;
 	self.imageView.userInteractionEnabled = YES;
+	// Enable edge antialiasing on 7.0 or later.
+	// This symbol appears pre-7.0 but is not considered public API until 7.0
+	if (([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending)) {
+		self.imageView.layer.allowsEdgeAntialiasing = YES;
+	}
 	[self.scrollView addSubview:self.imageView];
 	
 	/* setup gesture recognizers */

--- a/URBMediaFocusViewController.podspec
+++ b/URBMediaFocusViewController.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 	s.license			= { :type => 'MIT', :file => 'LICENSE' }
 	s.requires_arc		= true
 	s.source_files		= 'URBMediaFocusViewController.{h,m}'
-	s.frameworks		= 'UIKit', 'Foundation', 'CoreGraphics'
+	s.frameworks		= 'UIKit', 'Foundation', 'CoreGraphics', 'QuartzCore'
 end


### PR DESCRIPTION
The edges of rotated views will now be smoother when rotated off-axis.
See http://confusatory.org/post/78059850721/easy-antialiased-calayer-edges-on-ios-7-0-and-later for more info.

Examples:

Without edge anti-aliasing:

![not-1](https://cloud.githubusercontent.com/assets/474/2533263/c7ceaba8-b557-11e3-8ec1-aa6c799585c0.png)

![not-2](https://cloud.githubusercontent.com/assets/474/2533264/caad660c-b557-11e3-9701-05324656893b.png)

With anti-aliasing turned on:

![on-1](https://cloud.githubusercontent.com/assets/474/2533265/d20e3d68-b557-11e3-82fd-be25018e6892.png)
![on-2](https://cloud.githubusercontent.com/assets/474/2533266/d433c298-b557-11e3-9fe4-665356b9b5b4.png)
