### PR TITLE
Allow to dismiss the controller manually

### DIFF
--- a/URBMediaFocusViewController.h
+++ b/URBMediaFocusViewController.h
@@ -124,6 +124,11 @@
  */
 - (void)cancelURLConnectionIfAny;
 
+/**
+ *  Manually dismiss it
+ */
+- (void)dismiss:(BOOL)animated;
+
 @end
 
 @interface UIImage (URBAnimatedGIF)


### PR DESCRIPTION
Right now there is no way to manually dismiss the controller. Is there any issue with making the dismiss method public?